### PR TITLE
Make extension compatible with Firefox

### DIFF
--- a/overrides.css
+++ b/overrides.css
@@ -1,6 +1,3 @@
-.HeartAnimation {
-  background-image: url(chrome-extension://__MSG_@@extension_id__/web_heart_animation.png) !important;
-}
 /*heart badge next to likes on notifications page*/
 .Icon--communismBadge:before {
     content: "\262D";

--- a/overrides.js
+++ b/overrides.js
@@ -1,4 +1,6 @@
 (function() {
+  var browser = (typeof window.browser === "undefined" || Object.getPrototypeOf(browser) !== Object.prototype) ? window.chrome : window.browser;
+
   function $(selector) {
     return [].slice.call(document.querySelectorAll(selector));
   }
@@ -41,7 +43,7 @@
         return node.nodeType === Node.TEXT_NODE;
       }).forEach(nationalize);
     });
-    
+
     //can't rely on css alone becauese `content` property is not overrideable
     $(".Icon--heartBadge").forEach(function(el){
       el.classList.remove("Icon--heartBadge");
@@ -53,6 +55,11 @@
     checkForLikes();
     window.setTimeout(tick, 5000);
   }
+
+  var styleEl = document.createElement('style');
+  document.documentElement.appendChild(styleEl);
+
+  styleEl.sheet.insertRule(".HeartAnimation { background-image: url(" + browser.runtime.getURL("web_heart_animation.png") + ") !important; }", 0);
 
   tick();
 })();


### PR DESCRIPTION
Firefox does not allow easy access to resources (more [here](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources)), so we have to create and insert a new stylesheet on-the-fly. It seems this also has to be done for Chrome, so there could be some slowdown there. I couldn't find a way around it though.